### PR TITLE
fix(parser): support multiple tricolor stages at once

### DIFF
--- a/src/parser/stages/allStagesParser.ts
+++ b/src/parser/stages/allStagesParser.ts
@@ -7,7 +7,8 @@ export default function parseAllStages(json: any, translation: any): AllStagesRe
         ranked: [],
         xbattle: [],
         festSchedule: [],
-        triColorStage: null
+        triColorStage: null,
+        triColorStages: []
     };
 
     json.data.regularSchedules.nodes.forEach((node: any, index: number) => {
@@ -121,14 +122,23 @@ export default function parseAllStages(json: any, translation: any): AllStagesRe
     });
 
     if (json.data.currentFest) {
-        data.triColorStage = {
+        data.triColorStages = json.data.currentFest.tricolorStages ? json.data.currentFest.tricolorStages.map((stage: any) => ({
+            start_time: json.data.currentFest.startTime,
+            end_time: json.data.currentFest.endTime,
+            name: translation.stages[stage.id]?.name,
+            image: stage.image.url,
+            rulesImg: "https://file.strassburger.org/tricolor.svg",
+        })) : null;
+        data.triColorStage = json.data.currentFest.tricolorStage ? {
             start_time: json.data.currentFest.startTime,
             end_time: json.data.currentFest.endTime,
             name: translation.stages[json.data.currentFest.tricolorStage.id]?.name,
             image: json.data.currentFest.tricolorStage.image.url,
             rulesImg: "https://file.strassburger.org/tricolor.svg",
-        }
+        } : null;
+
     } else {
+        data.triColorStages.push(null);
         data.triColorStage = null;
     }
 

--- a/src/parser/stages/currentStagesParser.ts
+++ b/src/parser/stages/currentStagesParser.ts
@@ -116,14 +116,22 @@ export default function parseCurrentStages(json: any, translation: any): StagesR
     }
 
     if (json.data.currentFest) {
-        data.triColorStage = {
+        data.triColorStages = json.data.currentFest.tricolorStages ? json.data.currentFest.tricolorStages.map((stage: any) => ({
+            start_time: json.data.currentFest.startTime,
+            end_time: json.data.currentFest.endTime,
+            name: translation.stages[stage.id]?.name,
+            image: stage.image.url,
+            rulesImg: "https://file.strassburger.org/tricolor.svg",
+        })) : null;
+        data.triColorStage = json.data.currentFest.tricolorStage ? {
             start_time: json.data.currentFest.startTime,
             end_time: json.data.currentFest.endTime,
             name: translation.stages[json.data.currentFest.tricolorStage.id]?.name,
             image: json.data.currentFest.tricolorStage.image.url,
             rulesImg: "https://file.strassburger.org/tricolor.svg",
-        }
+        } : null;
     } else {
+        data.triColorStages = null
         data.triColorStage = null;
     }
 

--- a/src/parser/stages/nextStagesParser.ts
+++ b/src/parser/stages/nextStagesParser.ts
@@ -7,7 +7,8 @@ export default function parse(json: any, translation: any): StagesResponse {
         ranked: null,
         xbattle: null,
         festSchedule: null,
-        triColorStage: null
+        triColorStage: null,
+        triColorStages: []
     };
 
     if (json.data.regularSchedules.nodes[1].regularMatchSetting) {
@@ -114,14 +115,22 @@ export default function parse(json: any, translation: any): StagesResponse {
     }
 
     if (json.data.currentFest) {
-        data.triColorStage = {
+        data.triColorStages = json.data.currentFest.tricolorStages ? json.data.currentFest.tricolorStages.map((stage: any) => ({
+            start_time: json.data.currentFest.startTime,
+            end_time: json.data.currentFest.endTime,
+            name: translation.stages[stage.id]?.name,
+            image: stage.image.url,
+            rulesImg: "https://file.strassburger.org/tricolor.svg",
+        })) : null;
+        data.triColorStage = json.data.currentFest.tricolorStage ? {
             start_time: json.data.currentFest.startTime,
             end_time: json.data.currentFest.endTime,
             name: translation.stages[json.data.currentFest.tricolorStage.id]?.name,
             image: json.data.currentFest.tricolorStage.image.url,
             rulesImg: "https://file.strassburger.org/tricolor.svg",
-        }
+        } : null;
     } else {
+        data.triColorStages = null;
         data.triColorStage = null;
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -171,6 +171,7 @@ export interface StagesResponse {
     xbattle: SplatRotation | null;
     festSchedule: FestMatchSetting | null;
     triColorStage: SplatTricolorStage | null;
+    triColorStages: SplatTricolorStage[] | null;
 }
 
 /**
@@ -184,6 +185,7 @@ export interface AllStagesResponse {
     xbattle: (null | SplatRotation)[];
     festSchedule: (null | FestMatchSetting)[];
     triColorStage: SplatTricolorStage | null;
+    triColorStages: (null | SplatTricolorStage)[];
 }
 
 /**


### PR DESCRIPTION
My discord bot uses this package and stopped working today because the parsing of the tricolor stages fails, so I decided to check what the issue is and thought I might as well create a pull request while I'm at it 😅

## The issue
Before the grand festival, a splatfest would only have one tricolor tuf war stage per splatfest (with one exception). However since then (and for the splatfest this weekend), they added two tricolor stages to the rotation. 
The `currentStagesParser`, `nextStagesParser` and `allStagesParser` functions try to access `data.currentFest.tricolorStage` and add that to their respective response, but it is now null since there are now multiple tricolor stages that can be accessed through `data.currentFest.tricolorStages`.

## My change
I added another property `triColorStages` to the `StagesResponse` and `ALlStagesResponse`, that contains an array of `SplatTricolorStage` objects. I changed the parser functions to check whether `data.currentFest.tricolorStage` is undefined before assigning it and added a mapping for the array `data.currentFest.tricolorStages` with the same undefined check.

I didn't remove the single triColorStage property from the type to avoid a breaking change in this library. Also if Nintendo someday decides to make a splatfest with a single tricolor stage, the parser should still work.